### PR TITLE
Trim the refactor doc to what is still open

### DIFF
--- a/.github/workflows/build-site.yml
+++ b/.github/workflows/build-site.yml
@@ -6,10 +6,13 @@ name: Build site
 # This workflow is what publishes https://opensource.nibr.com/xgx/. Settings >
 # Pages > Source is set to "GitHub Actions" (changed 2026-08-11), so the live
 # site is whatever the `deploy` job below last uploaded -- not the HTML
-# committed in the repository. Background in
-# design/2026-08-03_Website_Refactor_Update.md.
+# committed in the repository.
 #
 # Every push and pull request builds. Only master deploys.
+#
+# This file and dev/ci/ are the description of how the site is built; there is
+# no separate design document to keep in step. Open questions about the site
+# live in design/2026-08-03_Website_Refactor_Update.md.
 
 on:
   push:

--- a/design/2026-08-03_Website_Refactor_Update.md
+++ b/design/2026-08-03_Website_Refactor_Update.md
@@ -1,152 +1,48 @@
-## Plan for Update (as of 2026-08-11) for first gen update
+# xGx Website Refactor — open items and next steps
 
-Everything below was on branch `andy-reorg-nochange`, which **merged to
-`Novartis/xgx` master on 2026-08-11** as PR #62. Steps 0–4 are complete and the
-live site is built by CI.
+**Updated 2026-08-11.** The first-generation update is finished: the site is
+built from source by GitHub Actions on every push to master, no rendered output
+is committed, and the data checking page has been rewritten as an IDA report.
 
-This is now the single record of that work. `design/2026-08-06_CI_Build_Pipeline.md`
-held the original proposal and rationale; it was deleted on 2026-08-11 once the
-pipeline was implemented, since the workflow file and `dev/ci/` are the live
-description and a proposal for something already built is just something else to
-keep in step. Its still-open items were carried into *Open items* below. The
-history is in git if the argument is ever needed again.
+Completed work is not described here. It is in git, as PRs
+[#62](https://github.com/Novartis/xgx/pull/62) (CI cutover and the `dev/`
+reorganisation), [#63](https://github.com/Novartis/xgx/pull/63) (deleting the
+committed build output), [#64](https://github.com/Novartis/xgx/pull/64) and
+[#65](https://github.com/Novartis/xgx/pull/65) (the data checking page), and
+[#66](https://github.com/Novartis/xgx/pull/66). The live description of how the
+build works is `.github/workflows/build-site.yml` and `dev/ci/`, not a document.
 
-### Already done on the branch
+What follows is only what is still open.
 
-- **CI pipeline built and proven.** `.github/workflows/build-site.yml` renders
-  all 27 pages from source and checks links. Demonstrated end to end on the
-  fork: https://iamstein.github.io/xgx/ (build 4m47s, deploy 19s).
-- **RxODE removed.** Migrated to `rxode2`, dataset generation made opt-in, and
-  the committed datasets in `Data/` are now treated as source (`12a2a77`,
-  `1a7ad39`). RxODE left CRAN 2022-10-10, so `PKPD_Datasets` had become
-  unbuildable by anyone.
-- **`xgx_scale_x_time_units` fixed** in six call sites for xgxr 1.1.6, which
-  rejects the `"h"`/`"d"` abbreviations (`2d54f80`). Decided: xgxr will *not*
-  restore the abbreviations — they were removed deliberately, so the fix
-  belongs here.
-- **JavaScript references fixed** in `SiteResources/README.html`. It pointed at
-  `jquery-1.11.3` and `highlightjs-1.1`, neither of which is still in
-  `site_libs/`, and every asset path was also one directory level too shallow.
-  Repointed to `jquery-3.6.0` / `highlightjs-9.12.0` and to `../site_libs/`, in
-  both the source copy under `Rmarkdown/SiteResources/` and the published copy
-  at the root. All eight now resolve.
-- **Developer-only material moved** into `dev/` (`f1cdea7`) — `Rlib/`, `Test/`
-  and the CI scripts. This is the part of the reorganisation that was safe to
-  do before CI is live.
+---
 
-### Step 0 — before anything else, Monday morning
+## Guiding principle — does not move
 
-**Does the Novartis org restrict GitHub Actions on public repositories?**
-Allowed-actions policies are common. `repos/Novartis/xgx/actions/permissions`
-is admin-only and returns 403, so this has to come from Orla or another admin.
-If Actions is restricted, the cutover below needs a different approach and it
-is better to know that before Alison spends time reviewing.
+**Nothing should break. Every page must continue to compile.**
 
-### Step 1 — cutover to CI — DONE 2026-08-11
+**`Data/`, `Rmarkdown/` and `Resources/` stay exactly where they are.** The
+published pages link directly into all three, and those URLs are cited in
+publications and from xgxr's CRAN listing. "Reorganise the folder structure"
+means *remove generated output from the root* — it does not mean relocating
+source directories. Link shapes that must keep working:
 
-1. **Done** — Alison reviewed the branch, including `PKPD_Datasets.Rmd`.
-2. **Done** — both deploy guards flipped from
-   `github.repository_owner != 'Novartis'` to `github.ref == 'refs/heads/master'`
-   (`cc3355a`).
-3. **Done** — merged to master as PR #62 (`e790042`). Build green, deploy 27s.
-4. **Done** — Pages Source set to "GitHub Actions". Confirmed via the API as
-   `build_type: workflow`. It is a maintain-level setting; no admin was needed.
-   Worth recording: the `github-pages` environment separately restricts
-   deployments to `master`, so a branch cannot publish to production.
-5. **Done** — verified against the done criteria below.
+    /xgx/Data/mt12345.csv
+    /xgx/Rmarkdown/Adverse_Events.Rmd
+    /xgx/Resources/Presentation_Checklist_v2.03.pdf
 
-One ordering hazard, since the note above got it backwards in practice: flipping
-the Pages setting *before* the workflow lands stops the legacy branch build
-without putting anything in its place. The site keeps serving its last legacy
-deployment, but goes stale — committing HTML no longer changes it. The window is
-harmless as long as the merge follows promptly, which is what happened.
+The public URL `opensource.nibr.com/xgx/` is unaffected by any of this — it
+comes from the org-level Pages domain plus the repository name, neither of
+which changes.
 
-Rollback **was** changing Pages Source back to "Deploy from a branch"
-(`master`, `/root`), which worked while the committed HTML was still in the
-repository. Step 2 removed it, so that route is gone; rollback now means
-reverting the merge, or `git revert` of the deletion commit to restore the root
-HTML first.
+---
 
-### Step 2 — clean-up — DONE 2026-08-11
+## Open items
 
-Done the same day as Step 1 rather than after a release cycle, at Andy's call,
-once the CI-built site had been verified serving correctly. 292 files removed.
+Found during the cleanup and deliberately not taken. These are editorial or
+content calls rather than build work, so they were left for someone who knows
+the material.
 
-Before deleting, every root `*.html` was checked against `Rmarkdown/*.Rmd`:
-all 27 had a source, so CI regenerates the lot and no page was lost.
-
-1. **Done** — deleted the ~27 `*.html` and their 17 `*_files/` companions, plus
-   `site_libs/`.
-2. **Done** — deleted the published copy of `SiteResources/` at the root.
-3. **Done** — deleted `SiteResources/README.html` outright, in both the root
-   copy and the source copy under `Rmarkdown/SiteResources/`. Nothing
-   references it; confirmed by grep across `.Rmd`, `.R`, `.yml`, `.html` and
-   `.py`.
-4. **Done** — root is now exactly `Rmarkdown/ Data/ Resources/ dev/ design/
-   README.md DESCRIPTION LICENSE.md .github/ .gitignore`.
-
-Two things done alongside, because the cleanup does not hold without them:
-
-* **`.gitignore` now ignores `/*.html`, `/*_files/`, `/site_libs/` and
-  `/SiteResources/`.** At the time, `Rmarkdown/000_render_site.R` still
-  shell-copied `www/` into the root, so without this the next person to run the
-  old local build recreated all 292 files and could recommit them.
-* **`README.md` rewritten** — it described the root as the published website
-  and told contributors to run `000_render_site.R`.
-
-### Step 3 — retire the old local build — DONE 2026-08-11
-
-`000_render_site.R` and both `_clear_cache` variants deleted. They were the
-mechanism that put build output in the root, so leaving them in place would
-have made Step 2 a matter of time rather than a fix.
-
-Replaced by `dev/render_site_local.R`:
-
-```r
-source("dev/render_site_local.R")
-render_xgx_site()                     # incremental
-render_xgx_site(clear_cache = TRUE)   # from scratch
-```
-
-It wraps `dev/ci/render_site_ci.R` — the same script CI runs, so local and CI
-builds cannot drift — and writes only into the gitignored `Rmarkdown/www/`.
-Cache clearing, the one thing the variants added that was worth keeping, clears
-both `*_cache` and `*_files`; clearing only the first is the trap that yields a
-build that looks fine while serving stale plots.
-
-`000_render_site_clear_cache_install_xgxr.R` was deleted rather than ported: it
-installed the vendored `dev/Rlib/xgxr_1.0.2.tar.gz`, and since `2d54f80` fixed
-the site for xgxr 1.1.6, running it would downgrade xgxr and break the build.
-
-### Step 4 — retire the orphaned xgxr 1.0.2 material — DONE 2026-08-11
-
-Deleting the install script orphaned the thing it installed. Removed, 72 files:
-
-* `dev/Rlib/` — the vendored xgxr 1.0.2 install and `xgxr_1.0.2.tar.gz`, 4.5 MB
-  and 67 files, ~35 of them `.html` help pages. This also resolves the
-  exception noted under the done criteria above: no `.html` is now committed
-  outside `Rmarkdown/SiteResources/`, with no caveat attached.
-* `dev/R/` — `xgx_functions_v2.R`, `xgx_functions_v3.R`,
-  `xgx_packages_functions.R`. Zero references; superseded by xgxr.
-* `Rmarkdown/xgx_stat_smooth.R` — a copy of package source nothing sourced.
-
-The last one is worth spelling out, because it looked live at a glance. Pages
-do call `xgx_stat_smooth()` and `xgx_geom_smooth_emax()`, so the file appears
-to be in use. But no `.Rmd` in the repository calls `source()` at all, and all
-six functions the file defines are in the xgxr 1.1.6 namespace. Those calls
-were always resolving to the package. The file was a stale fork of it.
-
-Also checked, nothing to do: every package declared in `DESCRIPTION` is used by
-at least one `.Rmd`.
-
-Note this does not shrink `.git`, which is ~588 MB largely from rendered images
-recommitted on every render. It stops it growing, which is the achievable win.
-
-### Open items — found during the cleanup, deliberately not taken
-
-These are editorial or content calls rather than build cleanup, so they were
-left for someone who knows the material. Carried over here when the CI design
-doc was deleted on 2026-08-11.
+### Content
 
 * **Three published pages are unreachable from the navigation** —
   `Multiple_Ascending_Dose_PD_receptor_occupancy`,
@@ -173,9 +69,9 @@ doc was deleted on 2026-08-11.
   | `Presentation_Outline_Template.pptx` | 28 KB |
 
   Documents, not build output, so the question is editorial: meant for the
-  Resources page and never linked, or superseded? `Presentation_Checklist_v2.04.docx`
-  is the sharpest case — the page links `v2.03.pdf`, so a newer revision sits
-  unlinked beside the old one.
+  Resources page and never linked, or superseded?
+  `Presentation_Checklist_v2.04.docx` is the sharpest case — the page links
+  `v2.03.pdf`, so a newer revision sits unlinked beside the old one.
 
 * **Five unreferenced images** in `Rmarkdown/SiteResources/`:
   `AE_vs_AUC_boxplots.png`, `Count_Hazard_Figure.png`, `Kaplan_Meier.png`,
@@ -184,73 +80,67 @@ doc was deleted on 2026-08-11.
 
 * **`dev/Test/`** — two scratch files, kept deliberately in `f1cdea7`.
 
+### Data
+
+* **Defects in `Data/Data_Checking.csv`**, surfaced by the integrity checks
+  added to the data checking page. The page reports them; the data has not been
+  fixed.
+
+  - Four covariates vary within a subject. `AGEB` takes nine distinct values
+    within subject 1, though it is a *baseline* covariate.
+  - Three duplicate event records on `USUBJID + CMT + EVID + TIME`.
+  - One subject has no observation records.
+  - `CENS` is set only on pre-dose records whose values sit *above* the LLOQ,
+    while 15 observations below the LLOQ are unflagged — so `CENS` in this
+    dataset is not marking BLQ, and `LLOQ = 10` is applied to the PD marker as
+    well as PK.
+
+### Repository size
+
 * **The two `.mp4` files are 177 MB of the working tree**, both genuinely used
   by the ACoP poster and tutorial pages. Deleting the root `SiteResources/`
   copy already halved this.
 
-* **Defects in `Data/Data_Checking.csv`** surfaced by the new integrity checks
-  on 2026-08-11: four covariates that vary within a subject (`AGEB` takes nine
-  distinct values within subject 1, though it is a *baseline* covariate), three
-  duplicate event records, and one subject with no observations. Also `CENS` is
-  set only on pre-dose records whose values sit *above* the LLOQ, while 15
-  observations below the LLOQ are unflagged — so `CENS` in this dataset is not
-  marking BLQ. The page now reports all of this; the data has not been fixed.
+* **`.git` is ~588 MB**, largely rendered images recommitted over the years.
+  The cutover stopped it growing but did not shrink it. Shrinking means
+  rewriting history, which breaks every existing clone and fork, and is not
+  obviously worth it.
 
-### Constraints — these do not move
+---
 
-**`Data/`, `Rmarkdown/` and `Resources/` stay exactly where they are.** The
-published pages link directly into all three, and those URLs are cited in
-publications and from xgxr's CRAN listing. "Reorganise the folder structure"
-means *remove generated output from the root* — it does not mean relocating
-source directories. Verified link shapes that must keep working:
+## Next generation
 
-    /xgx/Data/mt12345.csv
-    /xgx/Rmarkdown/Adverse_Events.Rmd
-    /xgx/Resources/Presentation_Checklist_v2.03.pdf
+Deferred deliberately, not forgotten.
 
-The public URL `opensource.nibr.com/xgx/` is unaffected by any of this — it
-comes from the org-level Pages domain plus the repository name, neither of
-which changes.
+### Repository and tooling
 
-### Done criteria
+- Before picking any of this up, look through the xGx MS Teams space and todos
+  and issues and see what else should be added.
+- The next version should be developed to enable AI development/use (i.e. use
+  the pages as templates) but also there will be skill files to help with data
+  checking and plot interpretation.
 
-- All 27 pages return 200.
-- The three link shapes above return 200.
-- `dev/ci/check_links.py` passes and the build is green.
-- No `.html` committed anywhere outside `Rmarkdown/SiteResources/`, which keeps
-  only the three fragments the build includes: `header.html`, `body.html`,
-  `icon_nav.html`. Met without caveat as of Step 4 — the ~35 help pages in the
-  vendored `dev/Rlib/xgxr/` install were the one exception, and that install is
-  now gone.
+### xGx usage
 
-### Not in this generation
+- Use a new caption that's a bit simpler.
+- Change the way `xgx_scale_x_time_units` is used. Scaling time in the
+  `ggplot()` object and just using `xgx_scale_x_time_units` to set breaks and
+  ticks. Maybe even create a new function for this, to put in xgxr — like
+  `xgx_breaks_x_time_units()` or something like that.
+- Look for places where code might be improved — like the dosing in the tumor
+  size RECIST plots.
 
-Andy is handling the **data checking page** update separately.
+### Data checking and exploration
 
-Explicitly deferred to a later generation, and tracked in the sections below:
-the new `xgx_breaks_x_time_units()` function in xgxr, the simpler caption, the
-AI/skill files, synpmx, and the RECIST dosing code improvements.
+The data checking page itself is done. What remains is the wider idea behind it:
 
-## xGx Refactor
-
-For many reasons, we'd like to update the xGx website.  The key guiding principle for the update though is that nothing should break.  Every page should continue to compile.  
-
-This should all be doen in a new branch.
-
-Before anything begins, look through the xGx MS Teams space and todos and issues and see what else should be added.
-
-## Organization
-
-- Should this site be organized a bit better?  I think so.  I don't like how so many files and folders are in the top directory.  Can this be reorganized without breaking anything.  
-- Should the html files be committed in git or compiled in git and git-pages?
-- The next version should be developde to enable AI development/use (i.e. use the pages as templates) but also there will be skill files to help with data checking and plot interpretation.
-
-## xGx usage
-
-- use a new caption that's a bit simpler.
-- change the way xgx_scale_x_time_units is used.  Scaling time in the ggplot() object and just using xgx_scale_x_time_units to set breaks and ticks.  Ah, maybe even create a new function for this, to put in xgxr.  like xgx_breaks_x_time_units() or something like that
-- look for places where code might be improved - like the dosing in the tumor size RECIST plots
-
-## Added functionality
-
-- The data checking and data exploration.  I had generated ideas for additional plots, maybe from dose finding toolbox.  Improve that.  Also, look for ideas for how to improve.  Think about if synpmx sohuld relate in some ways here as there is a validate function.  I've purposefully gone away from functions because they do make it harder for people to run and understand code line by line...  Revisit that idea
+- Additional plots, maybe from the dose finding toolbox. Look for ideas on how
+  to improve.
+- Think about whether synpmx should relate here, as it has a validate function.
+- Revisit the decision to avoid functions. Going away from functions was
+  deliberate — they make it harder for people to run and understand code line
+  by line — but it is worth revisiting.
+- The page's own parking lot carries the concrete follow-ups: checking a dataset
+  against a company data specification (a job for an agent, since spec formats
+  vary by company), an AI-assisted review of the exported summary, and the
+  `NMdata` / `apmx` / `pointblank` / `dataquieR` tooling options.


### PR DESCRIPTION
The document had become a record of finished work — five "DONE" step sections, a list of what was already done on the branch, and a met acceptance checklist. That is what git is for, and a plan that mostly describes the past is one people stop reading. **255 lines → 146.**

## Removed (all complete)

- "Already done on the branch"
- Step 0 — whether the org restricts Actions, answered by the pipeline running
- Steps 1–4 — CI cutover, root cleanup, retiring the old local build, retiring the xgxr 1.0.2 material
- "Done criteria" — met
- "Andy is handling the data checking page separately" — that page is done

A short header now points at PRs #62–#66 instead, and says plainly that `build-site.yml` and `dev/ci/` are the live description of how the site builds.

## Kept, reorganised into three sections

**Guiding principle** — nothing breaks, every page compiles, and `Data/`, `Rmarkdown/`, `Resources/` do not move because their paths are cited URLs.

**Open items** — three pages no navigation reaches, six unreferenced files in `Resources/`, five unreferenced images, `dev/Test/`, the defects in `Data_Checking.csv`, the mp4 sizes, and the ~588 MB `.git`.

> The `.git` note was buried at the tail of a completed step and would have been lost with it. Now filed under *Repository size*.

**Next generation** — the MS Teams sweep, AI/skill files, the simpler caption, `xgx_breaks_x_time_units()`, RECIST dosing, and the data exploration ideas including synpmx and whether to revisit the no-functions decision. Andy's original wording kept for these.

Verified every open item from the old version survives the rewrite.

Also corrected the pointer in `build-site.yml`, which sent readers to this document for background it no longer holds.
